### PR TITLE
Remove print from create source script

### DIFF
--- a/src/s08_create_source.py
+++ b/src/s08_create_source.py
@@ -42,9 +42,8 @@ if __name__ == "__main__":
         jar_paths = tuple(
             [f"file:///{os.path.join(CURRENT_DIR, 'jars', name)}" for name in jar_files]
         )
-        print(jar_paths)
         logging.info(f"adding local jars - {', '.join(jar_files)}")
-        env.add_jars(*jar_paths) 
+        env.add_jars(*jar_paths)
     
 
     skyone_source = (


### PR DESCRIPTION
## Summary
- remove stray debug print statement from `s08_create_source.py`
- confirm jars are still loaded using logging

## Testing
- `python -m pytest -q` *(fails: No module named 'pyflink')*
- `python src/s08_create_source.py` *(fails: ModuleNotFoundError: No module named 'pyflink')*

------
https://chatgpt.com/codex/tasks/task_e_6841d315fd6883259db58c5200ac663e