### PR TITLE
Add argparse to kafka consumer

### DIFF
--- a/src/s14_kafka_consumer.py
+++ b/src/s14_kafka_consumer.py
@@ -1,24 +1,38 @@
 from kafka import KafkaConsumer
-import sys
-topic=sys.argv[1]  
+import argparse
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Consume messages from a Kafka topic"
+    )
+    parser.add_argument(
+        "--topic",
+        help="Kafka topic to read from",
+        default="flightdata",
+    )
+    return parser.parse_args()
+
+
 KAFKA_CONSUMER_GROUP_NAME_CONS = "test-consumer-group"
-KAFKA_TOPIC_NAME_CONS = topic #"flightdata"
 KAFKA_BOOTSTRAP_SERVERS_CONS = "localhost:29092"
 
-if __name__ == "__main__":
-    
+
+def main() -> None:
+    args = parse_args()
+    topic = args.topic
+
     print("Kafka Consumer Application Started ... ")
     try:
         consumer = KafkaConsumer(
-            KAFKA_TOPIC_NAME_CONS,
+            topic,
             bootstrap_servers=KAFKA_BOOTSTRAP_SERVERS_CONS,
-            auto_offset_reset='latest',
+            auto_offset_reset="latest",
             enable_auto_commit=True,
             group_id=KAFKA_CONSUMER_GROUP_NAME_CONS,
-            # value_deserializer=lambda x: loads(x.decode('utf-8')))
-            value_deserializer=lambda x: x.decode('utf-8'))
+            value_deserializer=lambda x: x.decode("utf-8"),
+        )
         for message in consumer:
-            # print(dir(message))
             print(type(message))
             print("Key: ", message.key)
             message = message.value
@@ -26,3 +40,7 @@ if __name__ == "__main__":
     except Exception as ex:
         print("Failed to read kafka message.")
         print(ex)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- use argparse in the Kafka consumer example
- default to the `flightdata` topic if none specified

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pyflink')*

------
https://chatgpt.com/codex/tasks/task_e_6841d3261ca88325a82b77e1d16365e9